### PR TITLE
Added support for entity selectors

### DIFF
--- a/common/src/main/java/com/bencrow11/multieconomy/command/commands/ClearBalanceCommand.java
+++ b/common/src/main/java/com/bencrow11/multieconomy/command/commands/ClearBalanceCommand.java
@@ -19,11 +19,15 @@ import com.bencrow11.multieconomy.permission.PermissionManager;
 import com.bencrow11.multieconomy.util.Utils;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
+
+import java.util.List;
 
 /**
  * Creates the command "/meco clear" in game.
@@ -38,13 +42,13 @@ public class ClearBalanceCommand implements SubCommandInterface {
 	public LiteralCommandNode<CommandSourceStack> build() {
 		return Commands.literal("clear")
 				.executes(this::showUsage)
-				.then(Commands.argument("player", StringArgumentType.string())
-						.suggests((ctx, builder) -> {
-							for (String name : ctx.getSource().getOnlinePlayerNames()) {
-								builder.suggest(name);
-							}
-							return builder.buildFuture();
-						})
+				.then(Commands.argument("player", EntityArgument.players())
+//						.suggests((ctx, builder) -> {
+//							for (String name : ctx.getSource().getOnlinePlayerNames()) {
+//								builder.suggest(name);
+//							}
+//							return builder.buildFuture();
+//						})
 						.executes(this::showUsage)
 						.then(Commands.argument("currency", StringArgumentType.string())
 								.suggests((ctx, builder) -> {
@@ -76,9 +80,19 @@ public class ClearBalanceCommand implements SubCommandInterface {
 				return -1;
 			}
 		}
+		List<ServerPlayer> playerArguments;
+		try {
+			playerArguments = EntityArgument.getPlayers(context, "player").stream().toList();
+			playerArguments.forEach(player -> pay(context, playerSource, isPlayer, player.getDisplayName().getString()));
+		} catch (CommandSyntaxException ex) {
+			String playerArg = context.getInput().split(" ")[1];
+			pay(context, playerSource, isPlayer, playerArg);
+		}
 
-		// Collect the arguments from the command.
-		String playerArg = StringArgumentType.getString(context, "player");
+		return -1;
+	}
+
+	private int pay(CommandContext<CommandSourceStack> context, ServerPlayer playerSource, boolean isPlayer, String playerArg) {
 		String currencyArg = StringArgumentType.getString(context, "currency");
 
 		// Check the player has an account.

--- a/common/src/main/java/com/bencrow11/multieconomy/command/commands/RemoveBalanceCommand.java
+++ b/common/src/main/java/com/bencrow11/multieconomy/command/commands/RemoveBalanceCommand.java
@@ -20,11 +20,15 @@ import com.bencrow11.multieconomy.util.Utils;
 import com.mojang.brigadier.arguments.FloatArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
+
+import java.util.List;
 
 /**
  * Creates the command "/meco remove" in game.
@@ -39,13 +43,13 @@ public class RemoveBalanceCommand implements SubCommandInterface {
 	public LiteralCommandNode<CommandSourceStack> build() {
 		return Commands.literal("remove")
 				.executes(this::showUsage)
-				.then(Commands.argument("player", StringArgumentType.string())
-						.suggests((ctx, builder) -> {
-							for (String name : ctx.getSource().getOnlinePlayerNames()) {
-								builder.suggest(name);
-							}
-							return builder.buildFuture();
-						})
+				.then(Commands.argument("player", EntityArgument.players())
+//						.suggests((ctx, builder) -> {
+//							for (String name : ctx.getSource().getOnlinePlayerNames()) {
+//								builder.suggest(name);
+//							}
+//							return builder.buildFuture();
+//						})
 						.executes(this::showUsage)
 						.then(Commands.argument("currency", StringArgumentType.string())
 								.suggests((ctx, builder) -> {
@@ -86,8 +90,19 @@ public class RemoveBalanceCommand implements SubCommandInterface {
 			}
 		}
 
-		// Collect the arguments from the command.
-		String playerArg = StringArgumentType.getString(context, "player");
+		List<ServerPlayer> playerArguments;
+		try {
+			playerArguments = EntityArgument.getPlayers(context, "player").stream().toList();
+			playerArguments.forEach(player -> pay(context, playerSource, isPlayer, player.getDisplayName().getString()));
+		} catch (CommandSyntaxException ex) {
+			String playerArg = context.getInput().split(" ")[1];
+			pay(context, playerSource, isPlayer, playerArg);
+		}
+
+		return -1;
+	}
+
+	private int pay(CommandContext<CommandSourceStack> context, ServerPlayer playerSource, boolean isPlayer, String playerArg) {
 		String currencyArg = StringArgumentType.getString(context, "currency");
 		float amountArg = FloatArgumentType.getFloat(context, "amount");
 

--- a/common/src/main/java/com/bencrow11/multieconomy/command/commands/SetBalanceCommand.java
+++ b/common/src/main/java/com/bencrow11/multieconomy/command/commands/SetBalanceCommand.java
@@ -20,11 +20,15 @@ import com.bencrow11.multieconomy.util.Utils;
 import com.mojang.brigadier.arguments.FloatArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
+import net.minecraft.commands.arguments.EntityArgument;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
+
+import java.util.List;
 
 /**
  * Creates the command "/meco add" in game.
@@ -39,13 +43,13 @@ public class SetBalanceCommand implements SubCommandInterface {
 	public LiteralCommandNode<CommandSourceStack> build() {
 		return Commands.literal("set")
 				.executes(this::showUsage)
-				.then(Commands.argument("player", StringArgumentType.string())
-						.suggests((ctx, builder) -> {
-							for (String name : ctx.getSource().getOnlinePlayerNames()) {
-								builder.suggest(name);
-							}
-							return builder.buildFuture();
-						})
+				.then(Commands.argument("player", EntityArgument.players())
+//						.suggests((ctx, builder) -> {
+//							for (String name : ctx.getSource().getOnlinePlayerNames()) {
+//								builder.suggest(name);
+//							}
+//							return builder.buildFuture();
+//						})
 						.executes(this::showUsage)
 						.then(Commands.argument("currency", StringArgumentType.string())
 								.suggests((ctx, builder) -> {
@@ -86,8 +90,18 @@ public class SetBalanceCommand implements SubCommandInterface {
 			}
 		}
 
-		// Collect the arguments from the command.
-		String playerArg = StringArgumentType.getString(context, "player");
+		List<ServerPlayer> playerArguments;
+		try {
+			playerArguments = EntityArgument.getPlayers(context, "player").stream().toList();
+			playerArguments.forEach(player -> pay(context, playerSource, isPlayer, player.getDisplayName().getString()));
+		} catch (CommandSyntaxException ex) {
+			String playerArg = context.getInput().split(" ")[1];
+			pay(context, playerSource, isPlayer, playerArg);
+		}
+		return -1;
+	}
+
+	private int pay(CommandContext<CommandSourceStack> context, ServerPlayer playerSource, boolean isPlayer, String playerArg) {
 		String currencyArg = StringArgumentType.getString(context, "currency");
 		float amountArg = FloatArgumentType.getFloat(context, "amount");
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx8G
 minecraft_version=1.20
 archives_base_name=multieconomy
-mod_version=3.0.0
+mod_version=3.0.1
 maven_group=com.bencrow11
 architectury_version=5.14.76
 fabric_loader_version=0.14.21


### PR DESCRIPTION
This PR introduces the ability to use @p, @r and @e selectors alongside the standard Player Selector, closing this issue
[https://github.com/bencrow11/MultiEconomy/issues/2](https://github.com/bencrow11/MultiEconomy/issues/2)